### PR TITLE
✨(helm) add the django base Helm chart

### DIFF
--- a/charts/base-django/.helmignore
+++ b/charts/base-django/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/base-django/Chart.yaml
+++ b/charts/base-django/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: django
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"
+dependencies:
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 12.x.x

--- a/charts/base-django/README.md
+++ b/charts/base-django/README.md
@@ -1,0 +1,40 @@
+# Django Helm Chart 
+
+This chart's aim is to deploy a Django app using Helm. This chart follows the structure of the Django apps developed by 
+France Université Numérique. Is is intended to be used as a subchart for Django app Deployments. 
+
+This chart allows the user to either create a Postgresql database or connect to an external database (it depends on the variable `postgreqsl.enabled`)
+
+To deploy your own Django app, create your own Helm chart, add this one as a subchart and overwrite its parameters as needed. To do this you have to add a section in your own values file as follows:
+
+```
+django:
+  image:
+    repository: fundocker/<app_image>
+    pullPolicy: IfNotPresent
+    tag: <image_tag>
+  appDjangoSettingsModule: <settings_module>
+  appDjangoConfiguration: <app_configuration>
+
+```
+Since we have not yet created our own helm chart repository, in order to use this chart as a subchart, you need to:
+
+1) Go to this chart's directory: ` cd charts/base-django`
+
+2) Build its dependencies: ` helm dependency build `
+
+3) Package this chart: ` helm package . ` , a .tgz file will be created.
+
+4) Copy the .tgz in `<your-chart>/charts` directory
+
+It is possible to use existing Secrets or ConfigMaps for the deployment. In order to do this, you need to set the `extraEnvVarsSecret` and the `extraEnvVarsCM` variables with the name of the corresponding resource.
+
+One other way to set the environment variables is to deploy custom Secrets and ConfigMaps in the parent chart. For this to work, you need to deploy the custom secret with the following annotations:
+
+```
+    "helm.sh/hook": pre-upgrade, pre-install
+    "helm.sh/hook-weight": "-5"
+
+```
+
+For additional custom nginx configuration, this can be done using the `ingress.nginxServerSnippet` variable.

--- a/charts/base-django/templates/_helpers.tpl
+++ b/charts/base-django/templates/_helpers.tpl
@@ -1,0 +1,75 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "django.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "django.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "django.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "django.labels" -}}
+helm.sh/chart: {{ include "django.chart" . }}
+{{ include "django.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "django.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "django.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "django.imagePullSecrets" -}}
+{{- $pullSecrets := .Values.imagePullSecrets }}
+  {{- if (not (empty $pullSecrets)) }}
+imagePullSecrets:
+    {{- range $pullSecrets }}
+  - name: {{ . }}
+    {{ end }}
+  {{- end -}}
+{{- end }}
+
+{{/*
+Return the host
+*/}}
+{{- define "django.host" -}}
+{{- if .Values.appHost }}
+{{- .Values.appHost }}
+{{- else }}
+{{- .Release.Name }}.{{ .Release.Namespace }}.{{ .Values.domainName }}
+{{- end }}
+{{- end }}

--- a/charts/base-django/templates/app/configmap.yaml
+++ b/charts/base-django/templates/app/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "django.fullname" . }}-dotenv
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "django.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{ toYaml .Values.commonLabels | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/component: django
+  annotations:
+{{- if .Values.commonAnnotations }}
+{{- toYaml .Values.commonAnnotations | nindent 4 }}
+{{- end }}
+    "helm.sh/hook": pre-upgrade, pre-install
+    "helm.sh/hook-weight": "0"
+data:
+  DJANGO_SILENCED_SYSTEM_CHECKS: "security.W008,security.W004"
+  {{- if .Values.djangoAppEnvVars }}
+  {{- toYaml .Values.djangoAppEnvVars | nindent 2 }}
+  {{- end }}
+

--- a/charts/base-django/templates/app/deploy.yaml
+++ b/charts/base-django/templates/app/deploy.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "django.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "django.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{ toYaml .Values.commonLabels | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/component: django
+  {{- if .Values.commonAnnotations }}
+  annotations: {{ toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: {{- include "django.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: django
+  template:
+    metadata:
+      labels: {{- include "django.labels" . | nindent 8 }}
+        app.kubernetes.io/component: django
+        {{- if .Values.podLabels }}
+        {{ toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
+    spec: {{- include "django.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.affinity }}
+      affinity: {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels: {{- include "django.selectorLabels" . | nindent 20 }}
+                    app.kubernetes.io/component: django
+                namespaces: 
+                  - {{ .Release.Namespace | quote }}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: django
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          - containerPort: {{ .Values.service.port }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          env:
+            - name: DB_HOST
+              value: {{ include "django.fullname" . }}-postgresql
+            - name: DB_NAME
+              value: {{ .Values.databaseName }}
+            - name: DB_PORT
+              value: {{ .Values.databasePort | quote }}
+            - name: DJANGO_CONFIGURATION
+              value: {{ .Values.appDjangoConfiguration }}
+            - name: DJANGO_SETTINGS_MODULE
+              value: {{ .Values.appDjangoSettingsModule }}
+          envFrom:
+            - secretRef:
+                name: {{ include "django.fullname" . }}
+            - configMapRef:
+                name: {{ include "django.fullname" . }}-dotenv
+          {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+          {{- end }}
+          {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ .Values.extraEnvVarsCM }}
+          {{- end }}
+          {{- if .Values.customLivenessProbe }}
+          livenessProbe: {{- toYaml .Values.customLivenessProbe | nindent 12 }}
+          {{ else }}
+          livenessProbe:
+            httpGet:
+              path: {{.Values.livenessProbe.path }}
+              port: {{ .Values.service.port }}
+              httpHeaders:
+                - name: Host
+                  value: "{{ include  "django.host" .   }}"
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodeSeconds }}
+          {{- end }}
+          {{- if .Values.customReadinessProbe }}
+          readinessProbe: {{- toYaml .Values.customReadinessProbe | nindent 12 }}
+          {{ else }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.service.port }}
+              httpHeaders:
+                - name: Host
+                  value: "{{ include "django.host" .   }}"
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodeSeconds }}
+          {{- end }}
+          {{- if .Values.resources }}
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          {{- end }}

--- a/charts/base-django/templates/app/ingress.yaml
+++ b/charts/base-django/templates/app/ingress.yaml
@@ -1,0 +1,84 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "django.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "django.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{ toYaml .Values.commonLabels | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/component: django
+  annotations:
+{{- if .Values.commonAnnotations }}
+{{- toYaml .Values.commonAnnotations | nindent 4 }}
+{{- end }}
+{{- if .Values.ingress.acmeIssuerName }}
+    cert-manager.io/issuer: {{ .Values.ingress.acmeIssuerName }}
+{{- end }}
+{{- if .Values.ingress.activateHttpBasicAuth }}
+    nginx.ingress.kubernetes.io/auth-type: basic 
+    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.htpasswdSecretName }}
+    nginx.ingress.kubernetes.io/auth-realm: {{ .Values.ingress.httpBasicAuthMessage }}
+{{- end }}
+{{- if  and .Values.ingress.activateHttpBasicAuth .Values.ingress.bypassHtaccessIpWhitelist }}
+    nginx.ingress.kubernetes.io/satisfy: "any"
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ join "," .Values.ingress.bypassHtaccessIpWhitelist }}
+{{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: | 
+      {{ .Values.ingress.nginxConfigurationSnippet | nindent 6 }}
+    nginx.ingress.kubernetes.io/server-snippet: | 
+      {{ .Values.ingress.nginxServerSnippet | nindent 6 }}
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: {{ include "django.host" . | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Values.ingress.service }}
+            port:
+              number: {{ .Values.ingress.port }}
+  tls:
+    - hosts:
+      - {{ include "django.host" .  }}
+      secretName: {{ .Values.ingress.tlsSecretName }}
+---
+{{ if .Values.ingress.adminIpWhitelist }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "django.fullname" . }}-ingress-admin
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "django.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{ toYaml .Values.commonLabels | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/component: django
+  annotations:
+{{- if .Values.ingress.acmeIssuerName -}}
+    cert-manager.io/issuer: {{ .Values.ingress.acmeIssuerName }}
+{{ end }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ join "," .Values.ingress.adminIpWhitelist }}
+    nginx.ingress.kubernetes.io/server-snippet: | 
+      {{ .Values.ingress.nginxServerSnippet | nindent 6 }}
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: {{ include "django.host" . | quote }}
+    http:
+      paths:
+      - path: /admin
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Values.ingress.service }}
+            port:
+              number: {{ .Values.service.port }}
+  tls:
+    - hosts:
+      - {{ include "django.host" .  }}
+      secretName: {{ .Values.ingress.tlsSecretName }}
+{{ end }}

--- a/charts/base-django/templates/app/job_db_migrate.yaml
+++ b/charts/base-django/templates/app/job_db_migrate.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.appDjangoMigrate }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "django.fullname" . }}-dbmigrate
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "django.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{ toYaml .Values.commonLabels | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/component: django
+  annotations:
+{{- if .Values.commonAnnotations }}
+{{- toYaml .Values.commonAnnotations | nindent 4 }}
+{{- end }}
+    "helm.sh/hook": pre-upgrade, pre-install
+    "helm.sh/hook-weight": "0"
+spec:
+  template:
+    metadata:
+      labels: {{- include "django.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: django
+    spec: {{- include "django.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: django-dbmigrate
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: DB_HOST
+              value: {{ include "django.fullname" . }}-postgresql
+            - name: DB_NAME
+              value: {{ .Values.databaseName }}
+            - name: DB_PORT
+              value: {{ .Values.databasePort | quote }}
+            - name: DJANGO_ALLOWED_HOSTS
+              value: {{ include "django.host" . }}
+            - name: DJANGO_CONFIGURATION
+              value: {{ .Values.appDjangoConfiguration }}
+            - name: DJANGO_SETTINGS_MODULE
+              value: {{ .Values.appDjangoSettingsModule }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "django.fullname" . }}-dotenv
+            - secretRef:
+                name:  {{ include "django.fullname" . }}
+          {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+          {{- end }}
+          command: ["python", "manage.py", "migrate"]
+          {{- if .Values.resources }}
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+      restartPolicy: Never
+{{- end }}

--- a/charts/base-django/templates/app/secret.yaml
+++ b/charts/base-django/templates/app/secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "django.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "django.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{ toYaml .Values.commonLabels | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/component: django
+  annotations: 
+{{- if .Values.commonAnnotations }}
+{{- toYaml .Values.commonAnnotations | nindent 4 }}
+{{- end }}
+    "helm.sh/hook": pre-upgrade, pre-install
+    "helm.sh/hook-weight": "0"
+data: 
+  {{- range .Values.djangoAppSecrets }}
+  {{ .key }}: {{ .value | b64enc }}
+  {{- end }}
+

--- a/charts/base-django/templates/app/svc.yaml
+++ b/charts/base-django/templates/app/svc.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "django.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "django.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{ toYaml .Values.commonLabels | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/component: django
+  {{- if .Values.commonAnnotations }}
+  annotations: {{ toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - name: tcp-django
+    port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: {{ .Values.service.port }}
+  selector: {{- include "django.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: django

--- a/charts/base-django/templates/postgresql/endpoint.yaml
+++ b/charts/base-django/templates/postgresql/endpoint.yaml
@@ -1,0 +1,24 @@
+{{ if and ( not .Values.postgresql.enabled ) ( regexMatch "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$" .Values.endpointPostgresqlIp ) }}
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ include "django.fullname" . }}-postgresql
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "django.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{ toYaml .Values.commonLabels | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/component: postgresql
+  annotations:
+{{- if .Values.commonAnnotations }}
+{{- toYaml .Values.commonAnnotations | nindent 4 }}
+{{- end }}
+    "helm.sh/hook": pre-upgrade, pre-install
+    "helm.sh/hook-weight": "-5"
+subsets:
+  - addresses:
+    - ip: {{ .Values.endpointPostgresqlIp }}
+    ports:
+    - port: {{ .Values.databasePort }}
+      name: tcp-postgresql
+{{ end }}

--- a/charts/base-django/templates/postgresql/svc.yaml
+++ b/charts/base-django/templates/postgresql/svc.yaml
@@ -1,0 +1,24 @@
+{{ if not .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "django.fullname" . }}-postgresql
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "django.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{ toYaml .Values.commonLabels | nindent 4 }}
+    {{- end }}
+    app.kubernetes.io/component: postgresql
+  annotations:
+{{- if .Values.commonAnnotations }}
+{{- toYaml .Values.commonAnnotations | nindent 4 }}
+{{- end }}
+    "helm.sh/hook": pre-upgrade, pre-install
+    "helm.sh/hook-weight": "-5"
+spec:
+  ports:
+    - name: tcp-postgresql
+      port: {{ .Values.databasePort }}
+      protocol: TCP
+      targetPort: {{ .Values.databasePort }}
+{{- end }}

--- a/charts/base-django/values.yaml
+++ b/charts/base-django/values.yaml
@@ -1,0 +1,166 @@
+# Number of django replicas to deploy
+replicaCount: 1
+
+# Settings for django image
+image:
+  repository: fundocker/<app-image>
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: <image-tag>
+
+# Docker registry secret names as an array
+imagePullSecrets: []
+
+# String to partially override django.fullname template (will maintain the release name)
+nameOverride: ""
+
+# String to fully override django.fullname template
+fullnameOverride: ""
+
+# Labels to add to all deployed resources
+commonLabels: {}
+
+# Annotations to add to all deployed resources
+commonAnnotations: {}
+
+# Extra Labels for django pods
+podLabels: {}
+
+# Annotations for django pods
+podAnnotations: {}
+
+# django pods security context (https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+podSecurityContext: 
+  runAsUser: 10000
+  runAsGroup: 0
+
+# django service parameters
+service:
+  type: ClusterIP
+  port: 8000
+
+# django containers' resource requests and limits
+resources:
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 500Mi
+
+# Affinity for pod assignement
+affinity: {}
+
+# The cluster domain ( this variable is to be overwritten )
+domainName: localhost
+
+# The application host
+appHost: ""
+
+# django app Django settings to be used in deployement
+appDjangoSettingsModule: <app-settings>
+appDjangoConfiguration: <app-configuration>
+
+appDjangoMigrate: 0
+
+# django app secrets
+djangoAppSecrets: []
+  # - key: DJANGO_SECRET_KEY
+  #   value: ThisIsAnExampleKeyForTestPurposeOnly
+# FIXME uncomment this variable and replace with your sentry's credentials
+#  - key: DJANGO_SENTRY_DSN
+#    value: https://super:django@sentry.io/foo
+#  - key: DJANGO_JWT_PRIVATE_SIGNING_KEY
+#    value: "1234"
+
+# django app environment variables, remove the brackets and add 
+# the variables you need.
+djangoAppEnvVars: {}
+
+# Name of existing ConfigMap containing extra env vars for the django app nodes
+extraEnvVarsCM: ""
+
+# Name of existing Secret containing extra env vars for the django app nodes
+extraEnvVarsSecret: ""
+
+# Database settings used in the django app deployement
+## Postgresql database port
+databasePort: 5432
+## Postgresql database name
+databaseName: "django"
+
+# Configure options for the django app containers' liveness probe, readiness probe and container security.
+## django containers' liveness probe
+livenessProbe:
+  path:  /__heartbeat__ 
+  initialDelaySeconds: 60
+  periodSeconds: 30
+## django containers' readiness probe
+readinessProbe:
+  path: /__lbheartbeat__
+  initialDelaySeconds: 10
+  periodSeconds: 5
+## django containers' security context
+containerSecurityContext: 
+  enabled: false
+  runAsUser: 1001
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+
+# Configure the ingress nginx settings
+ingress:
+  service: ""
+  port: ""
+## Name of the cert-manager to be used to generate the tls secret
+  acmeIssuerName: ""
+## Activate the HTTP basic auth, a secret that contains the credentials needs to be created manually 
+## https://kubernetes.github.io/ingress-nginx/examples/auth/basic/
+  activateHttpBasicAuth: false
+  htpasswdSecretName: basic-auth
+  httpBasicAuthMessage: "Restricted Area"
+## List of IP addresses that can bypass the HTTP basic auth
+  bypassHtaccessIpWhitelist: []
+## List of the IP addresses that can access the /admin path
+  adminIpWhitelist: []
+## Name of the tls secret (this secret is either created manually or created by the cert-manager during deployement)
+  tlsSecretName: ""
+# Custom configuration for the server block in the nginx conf
+  nginxServerSnippet: ""
+
+  nginxConfigurationSnippet: ""
+
+# Set the variable postgresql.enabled to true if you want to deploy a database alongside the application django.
+# the bitnami postgresql helm chart is used for this purpose, the next section overrides the default values set
+# by the postgresql subchart.(https://artifacthub.io/packages/helm/bitnami/postgresql)
+postgresql:
+  commonAnnotations:
+    "helm.sh/hook": pre-upgrade, pre-install
+    "helm.sh/hook-weight": "-5"
+  enabled: true
+  image:
+    tag: 12
+  auth:
+    enablePostgreUser: false
+    username: fun
+    database: django
+    password: pass
+  primary:
+    livenessProbe:
+      enabled: false
+    readinessProbe:
+      enabled: false
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "100Mi"
+    podSecurityContext:
+      enabled: true 
+      runAsUser: 10000
+      runAsGroup: 0
+    containerSecurityContext:
+      enabled: false
+    persistence:
+      enabled: false
+
+# External database IP (only needed when postgresql.enabled set to false )
+endpointPostgresqlIp: ""


### PR DESCRIPTION
## Purpose

We want to avoid having to write all our Helm charts from scratch for the Django applications developed bu FUN.So we need a base chart that can reused for our Django apps deployement.

## Proposal
 - [x] Create a generic Django helm chart.
 - [x] Add placeholders and variables that allow total customization of the chart.
