### PR TITLE
Add Helm Chart Releaser GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR[bot]"
+          git config user.email "$GITHUB_ACTOR[bot]@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+      
+      - name: Add dependency repositories
+        run: |
+          for dir in $(ls -d charts/*/); do
+            helm dependency list $dir 2> /dev/null | tail -n2 | head -n -1 | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
+          done
+
+      - name: Relase charts
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: charts/
+          charts_repo_url: https://openfun.github.io/charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Hi! This pull request adds a GitHub Actions workflow to automatically publish changed charts to a Helm repository. It uses the official [helm/chart-releaser-action](https://github.com/helm/chart-releaser-action) GitHub Action.

This would aid in deploying Ralph with the Helm chart, as it currently requires manually cloning the chart.  
https://github.com/openfun/ralph/pull/238#discussion_r1130813019  
Should this PR be accepted the Ralph helm chart should be moved to this repository in a directory `charts/` and it will become available at a Helm repository `https://openfun.github.io/charts`.  The tarballs generated by Helm for the packages will be hosted as attachments to releases which the action also automatically creates.  
When using a pipeline like this it is important to always change the `version` value in `Chart.yaml` when changing the chart in any way.  

## Prerequisites:
* A `gh-pages` branch should be created with these files:
  * `_config.yml` with the content:
  	```yaml
	theme: minima
	name: Open FUN Helm Charts
	description: Open FUN Helm Repository
	```
  * `robots.txt` with the content:
	  ```
	User-Agent: *
	Disallow: /
     ```

This would make the steps for using the Ralph Helm chart easier and simplify the proposed documentation in https://github.com/openfun/ralph/pull/238  
