### PR TITLE
🔧(mailcatcher) add Helm chart for mailcatcher

### DIFF
--- a/mailcatcher/.gitignore
+++ b/mailcatcher/.gitignore
@@ -1,0 +1,1 @@
+mailcatcher-*.tgz

--- a/mailcatcher/.helmignore
+++ b/mailcatcher/.helmignore
@@ -1,0 +1,1 @@
+mailcatcher-*.tgz

--- a/mailcatcher/Chart.yaml
+++ b/mailcatcher/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+description: | 
+  MailCatcher runs a super simple SMTP server which catches any 
+  message sent to it to display in a web interface
+name: mailcatcher
+version: 0.0.1
+appVersion: 0.9.0

--- a/mailcatcher/README.md
+++ b/mailcatcher/README.md
@@ -1,0 +1,4 @@
+# Mailcatcher
+
+MailCatcher runs a super simple SMTP server which catches any 
+message sent to it to display in a web interface

--- a/mailcatcher/templates/_helpers.tpl
+++ b/mailcatcher/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{- define "mailcatcher.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "mailcatcher.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "mailcatcher.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mailcatcher.name" . }}
+app.kubernetes.io/part-of: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/component: mail
+{{- end }}
+

--- a/mailcatcher/templates/deployment.yaml
+++ b/mailcatcher/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+   name: {{ include "mailcatcher.fullname" . }}
+   labels:
+     {{- include "mailcatcher.selectorLabels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "mailcatcher.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mailcatcher.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ include "mailcatcher.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion)  }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          - containerPort: 1025
+            protocol: TCP
+          - containerPort: 1080
+            protocol: TCP

--- a/mailcatcher/templates/ingress.yaml
+++ b/mailcatcher/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "mailcatcher.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "mailcatcher.selectorLabels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if $.Values.ingress.tls.enable }}
+  tls:
+  - hosts:
+      - {{ $.Values.ingress.host }}
+    secretName: {{ $.Values.ingress.tls.certificateSecretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "mailcatcher.fullname" . }}
+                port:
+                  number: 1080
+{{- end }}

--- a/mailcatcher/templates/service.yaml
+++ b/mailcatcher/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mailcatcher.fullname" . }}
+  labels:
+    {{- include "mailcatcher.selectorLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 1080
+      targetPort: 1080
+      protocol: TCP
+      name: http
+    - port: 1025
+      targetPort: 1025
+      protocol: TCP
+      name: smtp
+  selector:
+    {{- include "mailcatcher.selectorLabels" . | nindent 3 }}

--- a/mailcatcher/values.schema.json
+++ b/mailcatcher/values.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "required": [
+    "image"
+  ],
+  "properties": {
+    "image": {
+      "type": "object",
+      "required": [
+        "repository",
+        "pullPolicy"
+      ],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[a-z0-9-_/]+$"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "pattern": "^(Always|Never|IfNotPresent)$"
+        }
+      }
+     },
+     "service": {
+      "type": "object",
+       "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+            "pattern": "^(ClusterIP)$"
+          }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "required": [
+        "enabled",
+        "className",
+        "annotations",
+        "tls"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "tls": {
+          "type": "object",
+          "required": [
+            "enable"
+          ],
+          "properties": {
+            "enable": {
+              "type": "boolean"
+            },
+            "certificateSecretName": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+  

--- a/mailcatcher/values.yaml
+++ b/mailcatcher/values.yaml
@@ -1,0 +1,15 @@
+image:
+  repository: sj26/mailcatcher
+  tag: ""
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations: {}
+  tls:
+    enable: false
+    certificateSecretName: ""


### PR DESCRIPTION
This Helm add install the sj26/mailcatcher app.
The Chart deploy the app and add 1 service for the the port HTTP and SMTP. And the ingress to access
to the web ui.